### PR TITLE
Signal handles and multi-axis support

### DIFF
--- a/python/lognplot/chart/chart.py
+++ b/python/lognplot/chart/chart.py
@@ -18,6 +18,7 @@ class Chart:
         self.x_axis = Axis()
         self.y_axis = Axis()
         self.curves = []
+        self.activeCurve = None
         self.db = db
 
     def has_curve(self, name):
@@ -30,9 +31,15 @@ class Chart:
         if not self.has_curve(name):
             curve = Curve(self.db, name, color)
             self.curves.append(curve)
+            self.change_active_curve(curve)
 
     def clear_curves(self):
         self.curves.clear()
+        self.y_axis = Axis()
+
+    def change_active_curve(self, curve):
+        self.activeCurve = curve
+        self.y_axis = self.activeCurve.axis
 
     def info(self):
         print(f"Chart with {len(self.curves)} series")

--- a/python/lognplot/chart/curve.py
+++ b/python/lognplot/chart/curve.py
@@ -14,7 +14,12 @@ class Curve:
         self._db = db
         self.name = name
         self.color = color
-        self.average = 0 # Average of the visual part of the curve
+        # Average of the visual part of the curve
+        self.average = 0
+        # Corresponding handle (polygon area)
+        self.handle = []
+        # Vertical adjustment by user
+        self.vertical_offset = 0
 
     def __repr__(self):
         return "Database proxy-curve"

--- a/python/lognplot/chart/curve.py
+++ b/python/lognplot/chart/curve.py
@@ -14,6 +14,7 @@ class Curve:
         self._db = db
         self.name = name
         self.color = color
+        self.average = 0 # Average of the visual part of the curve
 
     def __repr__(self):
         return "Database proxy-curve"

--- a/python/lognplot/chart/curve.py
+++ b/python/lognplot/chart/curve.py
@@ -1,5 +1,5 @@
 from ..tsdb.aggregation import Aggregation
-
+from .axis import Axis
 
 class Curve:
     """ A curve is a view onto a signal in the database.
@@ -18,8 +18,8 @@ class Curve:
         self.average = 0
         # Corresponding handle (polygon area)
         self.handle = []
-        # Vertical adjustment by user
-        self.vertical_offset = 0
+        # Each curve has its own vertical axis
+        self.axis = Axis()
 
     def __repr__(self):
         return "Database proxy-curve"

--- a/python/lognplot/qt/render/__init__.py
+++ b/python/lognplot/qt/render/__init__.py
@@ -5,7 +5,7 @@ from ...chart import Chart
 from .render import Renderer
 from .layout import ChartLayout
 from .options import ChartOptions
-
+from .transform import *
 
 def render_chart_on_qpainter(chart: Chart, painter: QtGui.QPainter, rect: QtCore.QRect):
     """ Call this function to paint a chart onto the given painter within the rectangle specified.

--- a/python/lognplot/qt/render/base.py
+++ b/python/lognplot/qt/render/base.py
@@ -35,7 +35,7 @@ class BaseRenderer:
         y_ticks = axis.get_ticks(amount_y_ticks)
         return y_ticks
 
-    def draw_grid(self, x_ticks, y_ticks):
+    def draw_grid(self, y_axis, x_ticks, y_ticks):
         """ Render a grid on the given x and y tick markers. """
         pen = QtGui.QPen(Qt.gray)
         pen.setWidth(1)
@@ -46,7 +46,7 @@ class BaseRenderer:
             self.painter.drawLine(x, self.layout.chart_top, x, self.layout.chart_bottom)
 
         for value, _ in y_ticks:
-            y = self.to_y_pixel(value)
+            y = self.to_y_pixel(y_axis, value)
             self.painter.drawLine(self.layout.chart_left, y, self.layout.chart_right, y)
 
     def draw_x_axis(self, x_ticks):
@@ -69,7 +69,7 @@ class BaseRenderer:
             text_y = y + 10 - text_rect.y()
             self.painter.drawText(text_x, text_y, label)
 
-    def draw_y_axis(self, y_ticks):
+    def draw_y_axis(self, y_axis, y_ticks):
         """ Draw the Y-axis. """
         pen = QtGui.QPen(Qt.black)
         pen.setWidth(2)
@@ -77,7 +77,7 @@ class BaseRenderer:
         x = self.layout.chart_right + 5
         self.painter.drawLine(x, self.layout.chart_top, x, self.layout.chart_bottom)
         for value, label in y_ticks:
-            y = self.to_y_pixel(value)
+            y = self.to_y_pixel(y_axis, value)
 
             # Tick handle:
             self.painter.drawLine(x, y, x + 5, y)

--- a/python/lognplot/qt/render/chart.py
+++ b/python/lognplot/qt/render/chart.py
@@ -21,13 +21,13 @@ class ChartRenderer(BaseRenderer):
     def render(self):
         """ Main entry point to start rendering a graph. """
 
-        self.draw_bouding_rect()
-
         x_ticks = self.calc_x_ticks(self.chart.x_axis)
         y_ticks = self.calc_y_ticks(self.chart.y_axis)
 
         if self.options.show_grid:
             self.draw_grid(x_ticks, y_ticks)
+
+        self.draw_bouding_rect()
 
         if self.options.show_axis:
             self.draw_x_axis(x_ticks)

--- a/python/lognplot/qt/render/chart.py
+++ b/python/lognplot/qt/render/chart.py
@@ -223,26 +223,22 @@ class ChartRenderer(BaseRenderer):
 
     def _draw_handles(self):
         x = self.layout.handles.left()
-        y = self.layout.handles.top() + self.layout.handles.height() / 3
 
         for _, curve in enumerate(self.chart.curves):
             handle_y = curve.average
-            x_full = self.options.handle_width #self.layout.handles.right()
+            x_full = self.options.handle_width
             x_half = x_full / 2
-            y_full = self.options.handle_height
-            y_half = y_full / 2
+            y_half = self.options.handle_height / 2
 
-            polygon = QtGui.QPainterPath(QtCore.QPoint(x, handle_y))
-            polygon.lineTo(QtCore.QPoint(x, handle_y))
-            polygon.lineTo(QtCore.QPoint(x + x_half, handle_y))
-            polygon.lineTo(QtCore.QPoint(x + x_full, handle_y + y_half))
-            polygon.lineTo(QtCore.QPoint(x + x_half, handle_y + y_full))
-            polygon.lineTo(QtCore.QPoint(x, handle_y + y_full))
+            polygon = QtGui.QPainterPath(QtCore.QPointF(x, handle_y - y_half))
+            polygon.lineTo(QtCore.QPointF(x, handle_y - y_half))
+            polygon.lineTo(QtCore.QPointF(x + x_half, handle_y - y_half))
+            polygon.lineTo(QtCore.QPointF(x + x_full, handle_y))
+            polygon.lineTo(QtCore.QPointF(x + x_half, handle_y + y_half))
+            polygon.lineTo(QtCore.QPointF(x, handle_y + y_half))
 
             color = QtGui.QColor(curve.color)
             self.painter.fillPath(polygon, QtGui.QBrush(color))
-
-            handle_y = handle_y + self.options.handle_height
 
     def to_x_pixel(self, value):
         return transform.to_x_pixel(value, self.chart.x_axis, self.layout)

--- a/python/lognplot/qt/render/layout.py
+++ b/python/lognplot/qt/render/layout.py
@@ -12,6 +12,11 @@ class ChartLayout:
         # print(rect, type(rect))
         self.rect = rect
 
+        self.handles = QtCore.QRect(self.rect.left() + self.options.padding,
+                                    self.rect.top(),
+                                    self.options.handle_width,
+                                    self.rect.height())
+
         # Endless sea of variables :)
         self.do_layout()
 
@@ -19,7 +24,12 @@ class ChartLayout:
         # self.right = self.rect.right()
         # self.bottom = self.rect.bottom()
         self.chart_top = self.rect.top() + self.options.padding
-        self.chart_left = self.rect.left() + self.options.padding
+
+        if self.options.show_handles:
+            self.chart_left = self.handles.right() + 1
+        else:
+            self.chart_left = self.rect.left() + self.options.padding
+
         if self.options.show_axis:
             axis_height = self.axis_height
             axis_width = self.axis_width

--- a/python/lognplot/qt/render/options.py
+++ b/python/lognplot/qt/render/options.py
@@ -2,4 +2,8 @@ class ChartOptions:
     def __init__(self):
         self.show_axis = True
         self.show_grid = True
+        self.show_legend = False
+        self.show_handles = True
         self.padding = 10
+        self.handle_width = 20
+        self.handle_height = 15

--- a/python/lognplot/qt/widgets/basewidget.py
+++ b/python/lognplot/qt/widgets/basewidget.py
@@ -24,6 +24,7 @@ class BaseWidget(QtWidgets.QWidget):
         super().mousePressEvent(event)
         self.disable_tailing()
         self._mouse_drag_source = event.x(), event.y()
+        self.mousePress(event.x(), event.y())
         self.update()
 
     def mouseMoveEvent(self, event):
@@ -34,6 +35,7 @@ class BaseWidget(QtWidgets.QWidget):
         super().mouseReleaseEvent(event)
         self._update_mouse_pan(event.x(), event.y())
         self._mouse_drag_source = None
+        self.mouseRelease(event.x(), event.y())
 
     def _update_mouse_pan(self, x, y):
         if self._mouse_drag_source:
@@ -41,9 +43,19 @@ class BaseWidget(QtWidgets.QWidget):
             if x != x0 or y != y0:
                 dy = y - y0
                 dx = x - x0
+                self.mouseDrag(x, y, dx, dy)
                 self.pan(dx, dy)
                 self._mouse_drag_source = (x, y)
                 self.update()
+
+    def mousePress(self, x, y):
+        pass
+
+    def mouseRelease(self, x, y):
+        pass
+
+    def mouseDrag(self, x, y, dx, dy):
+        pass
 
     def pan(self, dx, dy):
         """ Intended for subclasses to override.

--- a/python/lognplot/qt/widgets/chartwidget.py
+++ b/python/lognplot/qt/widgets/chartwidget.py
@@ -53,6 +53,7 @@ class ChartWidget(BaseWidget):
         print("pan", dx, dy)
         options1 = ChartOptions()
         layout = ChartLayout(self.rect(), options1)
+        self.repaint()
 
     def add_curve(self, name, color=None):
         if not self.chart.has_curve(name):
@@ -76,31 +77,37 @@ class ChartWidget(BaseWidget):
         self.chart.horizontal_zoom(amount)
         # Autoscale Y for a nice effect?
         self.chart.autoscale_y()
+        self.repaint()
         self.update()
 
     def vertical_zoom(self, amount):
         self.chart.vertical_zoom(amount)
+        self.repaint()
         self.update()
 
     def horizontal_pan(self, amount):
         self.chart.horizontal_pan(amount)
         # Autoscale Y for a nice effect?
         self.chart.autoscale_y()
+        self.repaint()
         self.update()
 
     def vertical_pan(self, amount):
         self.chart.vertical_pan(amount)
+        self.repaint()
         self.update()
 
     def zoom_fit(self):
         """ Autoscale all in fit! """
         self.chart.zoom_fit()
+        self.repaint()
         self.update()
 
     def zoom_to_last(self, span):
         """ Zoom to fit the last x time in view.
         """
         self.chart.zoom_to_last(span)
+        self.repaint()
         self.update()
 
     def enable_tailing(self, timespan):

--- a/python/lognplot/qt/widgets/chartwidget.py
+++ b/python/lognplot/qt/widgets/chartwidget.py
@@ -69,14 +69,14 @@ class ChartWidget(BaseWidget):
             curve = self.curveHandleAtPoint(x,y)
             if curve is not None:
                 self._drag_handle = curve
+                self.chart.change_active_curve(curve)
 
     def mouseRelease(self, x, y):
         self._drag_handle = None
 
     def mouseDrag(self, x, y, dx, dy):
         if self._drag_handle is not None:
-            #self.vertical_pan(float(dy) * 0.01) #self.PAN_FACTOR)
-            self._drag_handle.vertical_offset = self._drag_handle.vertical_offset + dy
+            self._drag_handle.axis.pan(dy / self.rect().height())
             self.repaint()
 
     # Intended to work together with the WIP minimap?


### PR DESCRIPTION
Maybe you can have a look at this? Not necessarily merge it right away, it probably needs some work / thinking, even if you would like this feature.
This branch prototyped multi-axis support, such that signals can individually scaled and panned, as it is quite common that correlated signals have a vast different domain. It also adds 'signal handles' to the left of the plot, similar to most digital oscilloscopes. This handle can be used for both panning and selecting that signal as being 'active'. Note that the vertical axis on the right is then changed to the active signal. While correct, this part needs some visual changes to ensure that it is clear to which signal the vertical axis belongs to.
I think something similar to this feature is useful to add the plotting of digital signals. It then allows you to organise the plot area, again similar to digital oscilloscopes.
Let me know what you think.